### PR TITLE
Add argument to support setting up nvim config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,8 @@ test-install-nvim:
 	docker run -it --rm \
 	-v $(PWD):/scripts \
 	ubuntu:22.04 /bin/bash -c "apt update -y && apt install -y wget && cd /scripts && chmod +x ./install_nvim.sh && ./install_nvim.sh && /bin/bash"
+
+test-install-nvim-with-config:
+	docker run -it --rm \
+	-v $(PWD):/scripts \
+	ubuntu:22.04 /bin/bash -c "apt update -y && apt install -y wget git jq && cd /scripts && chmod +x ./install_nvim.sh && ./install_nvim.sh -c isaacwassouf && /bin/bash"

--- a/configs.json
+++ b/configs.json
@@ -1,0 +1,5 @@
+{
+  "configs": {
+    "isaacwassouf": "https://github.com/isaacwassouf/nvim-config.git"
+  }
+}

--- a/install_nvim.sh
+++ b/install_nvim.sh
@@ -28,7 +28,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -c|--config)
             if [[ -z "$2" || "$2" == -* ]]; then
-                echo "Error: -c requires a config file argument"
+                echo "Error: -c requires a config name argument"
                 usage
             fi
             CONFIG="$2"

--- a/install_nvim.sh
+++ b/install_nvim.sh
@@ -9,8 +9,9 @@ CONFIG=""
 
 # Usage function
 usage() {
-    echo "Usage: $0 [-r RELEASE]"
+    echo "Usage: $0 [-r|--release RELEASE] [-c|--config CONFIG]"
     echo "  -r RELEASE    Specify the Neovim release to install"
+    echo "  -c CONFIG     Specify the config name to install"
     echo "  --help        Show this help message"
     exit 1
 }
@@ -57,12 +58,12 @@ fi
 
 install_config() {
     # check if the config exists in the configs.json
-    if jq '.configs | has("'$CONFIG'")' $SCRIPT_DIR/configs.json | grep -q "false"; then
+    if jq --arg config "$CONFIG" '.configs | has($config)' $SCRIPT_DIR/configs.json | grep -q "false"; then
         echo "Config $CONFIG does not exist in configs.json"
         exit 1
     fi
 
-    CONFIG_REPO=$(jq '.configs."'$CONFIG'"' $SCRIPT_DIR/configs.json | tr -d '"')
+    CONFIG_REPO=$(jq --arg config $CONFIG -r '.configs[$config]' $SCRIPT_DIR/configs.json)
 
     # create the config directory
     mkdir -p $HOME/.config

--- a/install_nvim.sh
+++ b/install_nvim.sh
@@ -58,7 +58,7 @@ fi
 install_config() {
     # check if the config exists in the configs.json
     if jq '.configs | has("'$CONFIG'")' $SCRIPT_DIR/configs.json | grep -q "false"; then
-        echo "Config $CONFIG does not exists in configs.json"
+        echo "Config $CONFIG does not exist in configs.json"
         exit 1
     fi
 


### PR DESCRIPTION
## Summary
This PR adds an argument, `-c` or `--config`, to the `install_nvim.sh` script to support setting up nvim configs after installation. 

Configs are stored in `configs.json` which would contain config owners and the URL to the config repo. The argument expects one of the owners, i.e., keys of `configs` node.