### PR TITLE
Add tmux session script

### DIFF
--- a/tmux_dev_session.sh
+++ b/tmux_dev_session.sh
@@ -14,21 +14,54 @@ twf() {
     echo "One tmux session at a time, please." >&2
     return 1
   fi
-
-  local session_name="${1:-$(basename "$PWD")}"
+  
+  # defaults
+  local session_name=$(basename "$PWD")
+  local extended_apps=()
+  
+  # parse options
+  while getopts ":s:e:" opt; do
+    case $opt in
+      s)
+        session_name="$OPTARG"
+        ;;
+      e)
+        extended_apps+=("$OPTARG")
+        ;;
+      :)
+        echo "Option -$OPTARG requires an argument." >&2
+        return 1
+        ;;
+      \?)
+        echo "Invalid option: -$OPTARG" >&2
+        return 1
+        ;;
+    esac
+  done
 
   if tmux has-session -t "$session_name" &> /dev/null; then
     echo "A session with this name already exists. Try another name." >&2
     return 1
   fi
 
+  # start the tmux session and the first window with nvim
   tmux new-session -d -s "$session_name" -n "nvim"
   tmux send-keys nvim C-m
 
+  # ceate additional windows for opencode and a shell session
   tmux new-window -n "opencode"
   tmux send-keys opencode C-m
 
   tmux new-window -n "shell"
 
+  # create windows for any additional apps
+  for app in "${extended_apps[@]}"; do
+    tmux new-window -n "$app"
+    tmux send-keys "$app" C-m
+  done
+  
+  # select the active window as nvim and attach to the session
   tmux select-window -t "nvim"
+  tmux attach-session -t "$session_name"
 }
+

--- a/tmux_dev_session.sh
+++ b/tmux_dev_session.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+for cmd in tmux opencode; do
+  # check if tmux is installed.
+  if ! command -v "$cmd" &> /dev/null; then
+      echo "Dude, You're missing $cmd." >&2
+      return 1
+  fi
+done
+
+# tmux with frinds :)
+twf() {
+  if [[ -n "$TMUX" ]]; then
+    echo "One tmux session at a time, please." >&2
+    return 1
+  fi
+
+  local session_name="${1:-$(basename "$PWD")}"
+
+  if tmux has-session -t "$session_name" &> /dev/null; then
+    echo "A session with this name already exists. Try another name." >&2
+    return 1
+  fi
+
+  tmux new-session -d -s "$session_name" -n "nvim"
+  tmux send-keys nvim C-m
+
+  tmux new-window -n "opencode"
+  tmux send-keys opencode C-m
+
+  tmux new-window -n "fuckaround"
+
+  tmux select-window -t "nvim"
+}

--- a/tmux_dev_session.sh
+++ b/tmux_dev_session.sh
@@ -28,7 +28,7 @@ twf() {
   tmux new-window -n "opencode"
   tmux send-keys opencode C-m
 
-  tmux new-window -n "fuckaround"
+  tmux new-window -n "shell"
 
   tmux select-window -t "nvim"
 }


### PR DESCRIPTION
# Summary
This PR adds a script `tmux_dev_session.sh` to quickly create a tmux session. The created session would have the following windows:
1. Neovim.
2. Opencode.
3. A Shell session.

The script takes the following options:

- `-s` to name the tmux session. If not provided it defaults to the base name of the current working directory.
- `-e` to add additional apps, each would be in a separate window. To add multiple apps, simple provide the option multiple times.

To use the script, source it first and then call the shell function `twf`.